### PR TITLE
Fix error log flooding by checking if groupfolder exist

### DIFF
--- a/w2g2/lib/File.php
+++ b/w2g2/lib/File.php
@@ -15,8 +15,8 @@ class File {
 
         $this->lock = empty($fileLocks) ? null : $fileLocks[0];
 
-        $groupFolderFile = (Database::getGroupFolderFile())[0];
-        $this->groupFolderFileId = $groupFolderFile['fileid'];
+        $groupFolderFile = empty(Database::getGroupFolderFile()) ? null : Database::getGroupFolderFile()[0];
+        $this->groupFolderFileId = ($groupFolderFile === null) ? null : $groupFolderFile['fileid'];
     }
 
     public function isLocked()


### PR DESCRIPTION
installations, which aren't using Nextclouds groupfolders, will get tons of false errors, accessing Database::getGroupFolderFile()[0].
Precheck, if there is any groupfolder, otherwise set null.