### PR TITLE
fix temp table creation issue and the root cause

### DIFF
--- a/w2g2/lib/Migration/PostMigration.php
+++ b/w2g2/lib/Migration/PostMigration.php
@@ -170,7 +170,7 @@ class PostMigration implements IRepairStep {
      */
     protected function dropTempTable()
     {
-        $dropStatement = "DROP TABLE " . $this->tempTableName;
+        $dropStatement = "DROP TABLE IF EXISTS " . $this->tempTableName;
 
         $this->db->executeQuery($dropStatement);
     }

--- a/w2g2/lib/Migration/PreMigration.php
+++ b/w2g2/lib/Migration/PreMigration.php
@@ -66,9 +66,19 @@ class PreMigration implements IRepairStep {
      */
     protected function createTempTable()
     {
+        /**
+         * cleanup temp table (issue #68)
+         */
+        $cleanupStatement = "DROP TABLE IF EXISTS " . $this->tempTableName;
+        $this->db->executeQuery($cleanupStatement);
+
+        /**
+        * create temp table
+        */
+
         $createStatement = "CREATE TABLE " .
             $this->tempTableName .
-            " (name varchar(255) PRIMARY KEY, created TIMESTAMP DEFAULT null, locked_by varchar(255))";
+            " (name varchar(255) PRIMARY KEY, locked_by varchar(255), created TIMESTAMP null DEFAULT null)";
 
         $this->db->executeQuery($createStatement);
     }
@@ -79,8 +89,8 @@ class PreMigration implements IRepairStep {
      */
     protected function insertDataInTempTable()
     {
-        $insertStatement = "INSERT INTO " . $this->tempTableName .
-            " SELECT * FROM " . $this->tableName;
+        $insertStatement = "INSERT INTO " . $this->tempTableName . " (name, locked_by, created)" .
+            " SELECT file_id, locked_by, created FROM " . $this->tableName;
 
         $this->db->executeQuery($insertStatement);
     }


### PR DESCRIPTION
failed drop table on older data migration cause issue #63 

root cause for failed lock table migration is described in #52  (data type mismatch) in case of wrong column order in sql